### PR TITLE
Fixed Local simc processing

### DIFF
--- a/internal/auto_download.py
+++ b/internal/auto_download.py
@@ -94,7 +94,7 @@ def _rename_directory(glob_path, commit):
 def _ensure_download_path():
     'Create and return the auto_download path'
     rootpath = os.path.dirname(os.path.realpath(__file__))
-    download_dir = os.path.join(rootpath, "..", "auto_download")
+    download_dir = os.path.join(rootpath, "auto_download")
     if not os.path.exists(download_dir):
         os.makedirs(download_dir)
     return download_dir
@@ -117,7 +117,7 @@ def _download_simc_version(url, filepath):
     'Download the specific file'
     print(f"Retrieving simc from url '{url}' to '{filepath}'.")
     with requests.get(url, timeout=10, stream=True) as req:
-        with open(filepath, 'wb', encoding="utf8") as handler:
+        with open(filepath, 'wb') as handler:
             shutil.copyfileobj(req.raw, handler)
 
 
@@ -129,10 +129,6 @@ def _unpack_file(seven_zip_executable, filepath, download_dir):
         subprocess.call(cmd)
 
         time.sleep(1)
-
-        # Nightly builds include their commit hash, we need to strip that out.
-        commit = filepath[: filepath.find(".7z")].rsplit("-")[-1]
-        _rename_directory(f"{download_dir}/simc-*-win64/", commit)
 
     except OSError as error:
         print(f"Exception when unpacking: {error}")

--- a/internal/sim_parser.py
+++ b/internal/sim_parser.py
@@ -9,7 +9,7 @@ def parse(filename, weights):
     """parse the given sim file"""
     separator = ','
     ret = ''
-    with open(filename, "r") as file:
+    with open(filename, "r", encoding="utf-8") as file:
         data = file.read()
         sim = json.loads(data)
         print("Parsing: " + filename)

--- a/internal/sim_parser.py
+++ b/internal/sim_parser.py
@@ -9,7 +9,7 @@ def parse(filename, weights):
     """parse the given sim file"""
     separator = ','
     ret = ''
-    with open(filename, "r", encoding="utf8") as file:
+    with open(filename, "r") as file:
         data = file.read()
         sim = json.loads(data)
         print("Parsing: " + filename)

--- a/internal/simc.py
+++ b/internal/simc.py
@@ -14,6 +14,7 @@ def sim_local(simc_path, profile_location, output_location, iterations):
                 [
                     simc_path,
                     f"json2={output_location}",
+                    f"iterations={iterations}",
                     profile_location
                 ], stdout=file, stderr=file)
         except Exception as ex:

--- a/internal/simc.py
+++ b/internal/simc.py
@@ -1,13 +1,14 @@
 """local simc functions"""
 import subprocess
 import os
-
+import time
 
 def sim_local(simc_path, profile_location, output_location, iterations):
     # pylint: disable=bare-except
     """sim against a local simc instance"""
     location_list = output_location.split("/")
-    with open(output_location.replace("json", "log"), 'w', encoding="utf8") as file:
+    logloc = output_location.replace("json", "log")
+    with open(logloc, 'w', encoding="utf8") as file:
         try:
             subprocess.check_call(
                 [
@@ -16,14 +17,12 @@ def sim_local(simc_path, profile_location, output_location, iterations):
                     f"iterations={iterations}",
                     profile_location
                 ], stdout=file, stderr=file)
-        except:
+        except Exception as ex:
+            print(ex)
             print(f"-- {location_list[-1]} has an error. Skipping file.")
-            with open(output_location.replace("json", "log"), encoding="utf8") as file:
-                lines = file.readlines()
-                print(f"-- {lines[-1]}")
-
-        os.remove(output_location.replace("json", "log"))
         file.close()
+        time.sleep(1)
+        os.remove(logloc)
 
 
 def raidbots(simc_path, profile_location, simc_build, output_location, report_name, iterations):

--- a/internal/simc.py
+++ b/internal/simc.py
@@ -17,7 +17,7 @@ def sim_local(simc_path, profile_location, output_location, iterations):
                     f"iterations={iterations}",
                     profile_location
                 ], stdout=file, stderr=file)
-        except Exception as ex:
+        except subprocess.CalledProcessError as ex:
             print(ex)
             print(f"-- {location_list[-1]} has an error. Skipping file.")
         file.close()

--- a/internal/simc.py
+++ b/internal/simc.py
@@ -1,32 +1,30 @@
 """local simc functions"""
 import subprocess
 import os
+import time
 
-
-def sim_local(simc_path, profile_location, output_location, iterations):
+def sim_local(simc_path, profile_location, output_location):
     # pylint: disable=bare-except
     """sim against a local simc instance"""
     location_list = output_location.split("/")
-    with open(output_location.replace("json", "log"), 'w', encoding="utf8") as file:
+    logloc = output_location.replace("json", "log")
+    with open(logloc, 'w', encoding="utf8") as file:
         try:
             subprocess.check_call(
                 [
                     simc_path,
                     f"json2={output_location}",
-                    f"iterations={iterations}",
                     profile_location
                 ], stdout=file, stderr=file)
-        except:
+        except Exception as ex:
+            print(ex)
             print(f"-- {location_list[-1]} has an error. Skipping file.")
-            with open(output_location.replace("json", "log"), encoding="utf8") as file:
-                lines = file.readlines()
-                print(f"-- {lines[-1]}")
-
-        os.remove(output_location.replace("json", "log"))
         file.close()
+        time.sleep(1)
+        os.remove(logloc)
 
 
 def raidbots(simc_path, profile_location, simc_build, output_location, report_name, iterations):
     # pylint: disable=unused-argument, too-many-arguments
     """just pass through to sim_local"""
-    sim_local(simc_path, profile_location, output_location, iterations)
+    sim_local(simc_path, profile_location, output_location)

--- a/internal/simc.py
+++ b/internal/simc.py
@@ -3,7 +3,7 @@ import subprocess
 import os
 import time
 
-def sim_local(simc_path, profile_location, output_location):
+def sim_local(simc_path, profile_location, output_location, iterations):
     # pylint: disable=bare-except
     """sim against a local simc instance"""
     location_list = output_location.split("/")
@@ -27,4 +27,4 @@ def sim_local(simc_path, profile_location, output_location):
 def raidbots(simc_path, profile_location, simc_build, output_location, report_name, iterations):
     # pylint: disable=unused-argument, too-many-arguments
     """just pass through to sim_local"""
-    sim_local(simc_path, profile_location, output_location)
+    sim_local(simc_path, profile_location, output_location, iterations)

--- a/internal/utils.py
+++ b/internal/utils.py
@@ -25,7 +25,7 @@ def get_simc_dir(talent, folder_name):
 
 
 def generate_parser(description):
-    """creates the shared argparser for sim.pu and profiles.py"""
+    """creates the shared argparser for sim.py and profiles.py"""
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('dir', help='Directory to generate profiles for.')
     parser.add_argument(
@@ -36,6 +36,14 @@ def generate_parser(description):
         '--ptr', help='indicate if the sim should use ptr data.', action='store_true')
     parser.add_argument(
         '--apl', help='indicate if the sim should use the custom apl.', action='store_true')
+    parser.add_argument(
+        '--iterations', help='Pass through specific iterations to run on. Default is 10000')
+    parser.add_argument(
+        '--local', help='indicate if the simulation should run local.', action='store_true')
+    parser.add_argument(
+        '--auto_download', help='indicate if we should automatically download latest simc.',
+        action='store_true'
+    )
     return parser
 
 

--- a/sim.py
+++ b/sim.py
@@ -141,14 +141,6 @@ def main():
     # pylint: disable=import-outside-toplevel,too-many-branches,unsupported-assignment-operation,duplicate-code
     """main function, runs and parses sims"""
     parser = utils.generate_parser("Parses a list of reports from Raidbots.")
-    parser.add_argument(
-        '--iterations', help='Pass through specific iterations to run on. Default is 10000')
-    parser.add_argument(
-        '--local', help='indicate if the simulation should run local.', action='store_true')
-    parser.add_argument(
-        '--auto_download', help='indicate if we should automatically download latest simc.',
-        action='store_true'
-    )
     args = parser.parse_args()
 
     sys.path.insert(0, args.dir)

--- a/suite.py
+++ b/suite.py
@@ -41,15 +41,19 @@ def generate_args(sim_dir, sim_type, script, args):
     arguments = ["python", script, sim_dir]
 
     if sim_type == "dungeons":
+        print("Running Dungeon Sim...")
         arguments.append("--dungeons")
 
     if args.ptr:
+        print("Running sims with PTR data...")
         arguments.append("--ptr")
 
     if args.apl:
+        print("Running sims with custom APL...")
         arguments.append("--apl")
 
     if args.local:
+        print("Running Locally...")
         arguments.append("--local")
 
     if args.local:

--- a/suite.py
+++ b/suite.py
@@ -89,9 +89,11 @@ def main():
     parser.add_argument(
         '--apl', help='indicate if the sim should use the custom apl.', action='store_true')
     parser.add_argument(
-        '--local', help='indicate if the sim should run locally (not recommended)', action='store_true')
+        '--local', help='indicate if the sim should run locally (not recommended)', 
+        action='store_true')
     parser.add_argument(
-        '--auto_download', help='if local enabled will grab the latest simc package', action='store_true')
+        '--auto_download', help='if local enabled will grab the latest simc package', 
+        action='store_true')
     args = parser.parse_args()
 
     if args.fresh or not os.path.exists(output_file):

--- a/suite.py
+++ b/suite.py
@@ -41,19 +41,15 @@ def generate_args(sim_dir, sim_type, script, args):
     arguments = ["python", script, sim_dir]
 
     if sim_type == "dungeons":
-        print("Running Dungeon Sim...")
         arguments.append("--dungeons")
 
     if args.ptr:
-        print("Running sims with PTR data...")
         arguments.append("--ptr")
 
     if args.apl:
-        print("Running sims with custom APL...")
         arguments.append("--apl")
 
     if args.local:
-        print("Running Locally...")
         arguments.append("--local")
 
     if args.local:

--- a/suite.py
+++ b/suite.py
@@ -36,32 +36,38 @@ def check_state(sim_dir, sim_type, output_file, script):
     return True
 
 
-def generate_args(sim_dir, sim_type, script, ptr, apl):
+def generate_args(sim_dir, sim_type, script, args):
     """generates arguments for each script based on input"""
     arguments = ["python", script, sim_dir]
 
     if sim_type == "dungeons":
         arguments.append("--dungeons")
 
-    if ptr:
-        arguments.append(ptr)
+    if args.ptr:
+        arguments.append("--ptr")
 
-    if apl:
-        arguments.append(apl)
+    if args.apl:
+        arguments.append("--apl")
+
+    if args.local:
+        arguments.append("--local")
+
+    if args.local:
+        arguments.append("--auto_download")
 
     return arguments
 
 
-def run_suite(sim_dir, sim_type, output_file, sim, ptr, apl):
+def run_suite(sim_dir, sim_type, output_file, sim, args):
     # pylint: disable=too-many-arguments
     """helper function to orchestrate other calls"""
     if check_state(sim_dir, sim_type, output_file, "profiles"):
-        call_process(generate_args(sim_dir, sim_type, "profiles.py", ptr, apl))
+        call_process(generate_args(sim_dir, sim_type, "profiles.py", args))
         update_state(sim_dir, sim_type, output_file, "profiles")
 
     if check_state(sim_dir, sim_type, output_file, "sim"):
         print(f"Running sim suite for {sim} - {sim_type}")
-        call_process(generate_args(sim_dir, sim_type, "sim.py", ptr, apl))
+        call_process(generate_args(sim_dir, sim_type, "sim.py", args))
         update_state(sim_dir, sim_type, output_file, "sim")
 
 
@@ -82,22 +88,16 @@ def main():
         '--dungeons', help='only run the dungeon suite', action='store_true')
     parser.add_argument(
         '--apl', help='indicate if the sim should use the custom apl.', action='store_true')
+    parser.add_argument(
+        '--local', help='indicate if the sim should run locally (not recommended)', action='store_true')
+    parser.add_argument(
+        '--auto_download', help='if local enabled will grab the latest simc package', action='store_true')
     args = parser.parse_args()
 
     if args.fresh or not os.path.exists(output_file):
         with open(output_file, 'w', encoding="utf8") as file:
             file.write('dir,type,sim,\n')
             file.close()
-
-    ptr = ""
-    if args.ptr:
-        print("Running sims with PTR data...")
-        ptr = "--ptr"
-
-    apl = ""
-    if args.apl:
-        print("Running sims with custom APL...")
-        apl = "--apl"
 
     for sim in config["sims"].keys():
         if sim in args.exclude:
@@ -107,8 +107,8 @@ def main():
         # By default run Composite and Dungeons suite
         # Can pass in --dungeons to ONLY run the Dungeons suite
         if not args.dungeons:
-            run_suite(sim_dir, "composite", output_file, sim, ptr, apl)
-        run_suite(sim_dir, "dungeons", output_file, sim, ptr, apl)
+            run_suite(sim_dir, "composite", output_file, sim, args)
+        run_suite(sim_dir, "dungeons", output_file, sim, args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Local suite runs weren't running due to the args not being pushed through the chain correctly and reaching the local implementation and then the simc autodownload.

This also contains some bugfixes:
Crashing bug trying to open executable with encoding
It saving the simc output as a "json" file and then crashing on the parse step

This commit cleans up the arg processing with suite.py generate_args now doing all the argument creation rather than some in main and some in generate_args 

There are some sleeps still lying around in regards to file management I want to clean up but it's for a later day

Tested to not have an effect on the main raidbots use case