### PR TITLE
swd prio testing

### DIFF
--- a/apl/default_apl.simc
+++ b/apl/default_apl.simc
@@ -31,10 +31,12 @@ actions.aoe+=/call_action_list,name=cds,if=fight_remains<30|time_to_die>15&(!var
 actions.aoe+=/mindbender,if=(dot.shadow_word_pain.ticking&variable.vts_applied|action.shadow_crash.in_flight&talent.whispering_shadows)&(fight_remains<30|time_to_die>15)
 # Use Mind Blast when capped on charges and talented into Mind Devourer to fish for the buff or if Inescapable Torment is talented with Mindbender active. Only use when facing 3-7 targets.
 actions.aoe+=/mind_blast,if=(cooldown.mind_blast.full_recharge_time<=gcd.max+cast_time|pet.fiend.remains<=cast_time+gcd.max)&pet.fiend.active&talent.inescapable_torment&pet.fiend.remains>cast_time&active_enemies<=7&!buff.mind_devourer.up
+actions.aoe+=/shadow_word_death,if=pet.fiend.remains<=2&pet.fiend.active&talent.inescapable_torment&active_enemies<=7
 actions.aoe+=/void_bolt
 # Use Devouring Plague to maximize uptime. Short circuit if you are capping on Insanity within 20 or to get out an extra Void Bolt by extending Voidform. With Distorted Reality can maintain more than one at a time in multi-target.
 actions.aoe+=/devouring_plague,target_if=remains<=gcd.max|!talent.distorted_reality,if=remains<=gcd.max&!variable.pool_for_cds|insanity.deficit<=20|buff.voidform.up&cooldown.void_bolt.remains>buff.voidform.remains&cooldown.void_bolt.remains<=buff.voidform.remains+2
 actions.aoe+=/vampiric_touch,target_if=refreshable&target.time_to_die>=18&(dot.vampiric_touch.ticking|!variable.vts_applied),if=variable.max_vts>0&(cooldown.shadow_crash.remains>=dot.vampiric_touch.remains|variable.holding_crash)&!action.shadow_crash.in_flight|!talent.whispering_shadows
+actions.aoe+=/shadow_word_death,if=variable.vts_applied&talent.inescapable_torment&pet.fiend.active&((!talent.insidious_ire&!talent.idol_of_yoggsaron)|buff.deathspeaker.up)
 # High Priority Mind Spike: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available and Mindbender is not active
 actions.aoe+=/mind_spike_insanity,if=variable.dots_up&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
 # High Priority Mind Flay: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available and Mindbender is not active
@@ -105,6 +107,7 @@ actions.main+=/call_action_list,name=cds,if=fight_remains<30|time_to_die>15&(!va
 actions.main+=/mindbender,if=variable.dots_up&(fight_remains<30|time_to_die>15)
 # High priority Mind Blast action when using Inescapable Torment
 actions.main+=/mind_blast,target_if=(dot.devouring_plague.ticking&(cooldown.mind_blast.full_recharge_time<=gcd.max+cast_time)|pet.fiend.remains<=cast_time+gcd.max)&pet.fiend.active&talent.inescapable_torment&pet.fiend.remains>cast_time&active_enemies<=7
+actions.main+=/shadow_word_death,target_if=dot.devouring_plague.ticking&pet.fiend.remains<=2&pet.fiend.active&talent.inescapable_torment&active_enemies<=7
 actions.main+=/void_bolt,if=variable.dots_up
 # Spend your Insanity on Devouring Plague at will if the fight will end in less than 10s
 actions.main+=/devouring_plague,if=fight_remains<=duration+4
@@ -114,6 +117,7 @@ actions.main+=/devouring_plague,target_if=!talent.distorted_reality|active_enemi
 actions.main+=/shadow_crash,if=!variable.holding_crash&dot.vampiric_touch.refreshable
 # Put out Vampiric Touch on enemies that will live at least 12s and Shadow Crash is not available soon
 actions.main+=/vampiric_touch,target_if=min:remains,if=refreshable&target.time_to_die>=12&(cooldown.shadow_crash.remains>=dot.vampiric_touch.remains&!action.shadow_crash.in_flight|variable.holding_crash|!talent.whispering_shadows)
+actions.main+=/shadow_word_death,if=variable.dots_up&talent.inescapable_torment&pet.fiend.active&((!talent.insidious_ire&!talent.idol_of_yoggsaron)|buff.deathspeaker.up)
 # High Priority Mind Spike: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available
 actions.main+=/mind_spike_insanity,if=variable.dots_up&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
 # High Priority Mind Flay: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available


### PR DESCRIPTION
adds a high prio swd action if bender is about to expire and a slightly lower prio version that casts it with bender active but not insidious ire or yogg talented

# Single - yshaarj-cthun
| Actor | DPS | Increase |
|---|:---:|:---:|
|higher_prio_swd_bender_expire|117636|0.05%|
|Base|117574|0.00%|

# 4T - yshaarj-cthun
| Actor | DPS | Increase |
|---|:---:|:---:|
|higher_prio_swd_bender_expire|263578|0.60%|
|Base|262004|0.00%|

# Dungeons - yshaarj-cthun
| Actor | DPS | Increase |
|---|:---:|:---:|
|higher_prio_swd_bender_expire|126621|1.01%|
|Base|125356|0.00%|


example aoe sim: https://www.raidbots.com/simbot/report/2f9jynVmThUGC2axMWn7KE